### PR TITLE
Properly handle case where webhook_url is empty/missing

### DIFF
--- a/assets/resource.py
+++ b/assets/resource.py
@@ -84,12 +84,12 @@ Job: #{1} {2}
         }
 
         if not url:
-            print("Missing 'webhock_url' under resource source.\nSkip posting to GoogleChat.", file=sys.stderr)
+            print("Missing 'webhook_url' under resource source.\nSkip posting to GoogleChat.", file=sys.stderr)
             response["metadata"] += [
                 {"name": "status", "value": "Failed"},
-                {"name": "error", "value": "Missing 'webhock_url' in source"}
+                {"name": "error", "value": "Missing 'webhook_url' in source"}
             ]
-            return json.dumps(response)
+            return response
 
         status, text = self.send(url, text)
         api_res = json.loads(text)


### PR DESCRIPTION
Hi,

Thanks for spending time on this resource and making it open-source. We moved to Google ~hangouts~ ~allo~ chat recently and we need to emit IM notifications there.

I noticed a blocking issue when using your resource without a webhook_url. Here's the fix :-)

(We *do* omit the hook URL if we don't want notifications - for example when the pipeline is executed against dev environments)

### Changes:
- Fix typo in error message when missing webhook_url.
- Fix ATC complaining that resource.versionResult cannot be unmarshalled when the webhook_url parameter is empty/missing, causing the ATC to flag the related job as `errored` instead of `failed`.

-----------------------

### Current behaviour:
```
Missing 'webhock_url' under resource source.
Skip posting to GoogleChat.

json: cannot unmarshal string into Go value of type resource.versionResult
```
The last line is coming from the ATC, which flags the related job as errored, instead of failed.

### Fixed behaviour:
```
Missing 'webhook_url' under resource source.
Skip posting to GoogleChat.
```
(No ATC error - the related job gracefully fails)